### PR TITLE
Fix some Mistakes in Geometry, Layout, and Component.Form

### DIFF
--- a/examples/gallery/gallery.ipkg
+++ b/examples/gallery/gallery.ipkg
@@ -1,9 +1,48 @@
 package gallery
 version = 0.1.0
 authors = "emdash"
+-- maintainers =
+-- license =
+-- brief =
+-- readme =
+-- homepage =
+-- sourceloc =
+-- bugtracker =
 
+-- the Idris2 version required (e.g. langversion >= 0.5.1)
+-- langversion
+
+-- packages to add to search path
 depends = contrib
 	, tui
 
+-- modules to install
+-- modules =
+
+-- main file (i.e. file to load at REPL)
 main = Main
+
+-- name of executable
+executable = "gallery"
+-- opts =
 sourcedir = "src"
+-- builddir =
+-- outputdir =
+
+-- script to run before building
+-- prebuild =
+
+-- script to run after building
+-- postbuild =
+
+-- script to run after building, before installing
+-- preinstall =
+
+-- script to run after installing
+-- postinstall =
+
+-- script to run before cleaning
+-- preclean =
+
+-- script to run after cleaning
+-- postclean =

--- a/examples/gallery/run.sh
+++ b/examples/gallery/run.sh
@@ -34,4 +34,12 @@ function shim {
     python input-shim.py 2>shim_log
 }
 
-shim | ./build/exec/ampii "$@" 2> debug_log
+case "$1" in
+    --debug)
+	shift
+	export IDRIS_TUI_MAINLOOP="input-shim"
+	shim | ./build/exec/gallery "$@" 2> debug_log
+	;;
+    *)
+	./build/exec/gallery
+esac

--- a/examples/gallery/run.sh
+++ b/examples/gallery/run.sh
@@ -29,6 +29,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+shopt -s checkwinsize; (:;:)
+
+export LINES="${LINES}"
+export COLUMNS="${COLUMNS}"
 
 function shim {
     python input-shim.py 2>shim_log
@@ -42,4 +46,5 @@ case "$1" in
 	;;
     *)
 	./build/exec/gallery
+	;;
 esac

--- a/src/TUI/Layout.idr
+++ b/src/TUI/Layout.idr
@@ -53,9 +53,43 @@ export
 packTop : View v => State -> Rect -> v -> Context Rect
 packTop state window self = do
   let split = (size self).height
-  let (top, bottom) = vsplit window split
+  let (top, bottom) = window.splitTop split
   paint state top self
   pure bottom
+
+||| Paint the given view into the bottom of the given window.
+|||
+||| Return the remaning space in the window.
+export
+packBottom : View v => State -> Rect -> v -> Context Rect
+packBottom state window self = do
+  let split = (size self).height
+  let (top, bottom) = window.splitBottom split
+  paint state bottom self
+  pure top
+
+||| Paint the given view into the left of the given window.
+|||
+||| Return the remaning space in the window.
+export
+packLeft : View v => State -> Rect -> v -> Context Rect
+packLeft state window self = do
+  let split = (size self).width
+  let (left, right) = window.splitLeft split
+  paint state left self
+  pure right
+
+||| Paint the given view into the right of the given window.
+|||
+||| Return the remaning space in the window.
+export
+packRight : View v => State -> Rect -> v -> Context Rect
+packRight state window self = do
+  let split = (size self).width
+  let (left, right) = window.splitRight split
+  paint state right self
+  pure left
+
 
 ||| Paint the given list of views, laying them out vertically within
 ||| `window`.
@@ -73,17 +107,6 @@ paintVertical state window (x :: xs) = paintVertical state !(packTop state windo
 export
 sizeHorizontal : View itemT => List itemT -> Area
 sizeHorizontal self = foldl (flip $ vunion . size) (MkArea 0 0) self
-
-||| Paint the given view into the left of the given window.
-|||
-||| Return the remaning space in the window.
-export
-packLeft : View v => State -> Rect -> v -> Context Rect
-packLeft state window self = do
-  let split = (size self).width
-  let (left, right) = hdivide window split
-  paint state left self
-  pure right
 
 ||| Paint the given list of views, laying them out vertically within
 ||| `window`.
@@ -109,21 +132,3 @@ View Rule where
 
   paint _ window HRule = hline window.nw window.size.width
   paint _ window VRule = vline window.nw window.size.height
-
-||| Paint two views into the given rectangle with a vertical line
-||| between them.
-export
-hpane
-  : View leftT
-  => View rightT
-  => State
-  -> Rect
-  -> leftT
-  -> rightT
-  -> Nat
-  -> Context ()
-hpane state window left right split = do
-  let (l_window, r_window) = hdivide window split
-  paint state l_window left
-  vline (MkPos split window.n) window.size.height
-  paint state r_window right

--- a/src/TUI/Painting.idr
+++ b/src/TUI/Painting.idr
@@ -184,14 +184,13 @@ namespace Box
   ||| Fill a rectangle with the given character
   export
   fill : Char -> Rect -> Context ()
-  fill c box = loop box.size.height
+  fill c box = loop box.height box.nw
     where
-      loop : Nat -> Context ()
-      loop Z = pure ()
-      loop i@(S n) = do
-        let pos = MkPos box.pos.x i
-        showTextAt pos $ replicate box.size.width c
-        loop n
+      loop : Nat -> Pos -> Context ()
+      loop Z _ = pure ()
+      loop i@(S n) pos = do
+        showTextAt pos $ replicate box.width c
+        loop n $ pos.shiftDown 1
 
   ||| Draw a box around the given rectangle
   |||
@@ -200,10 +199,10 @@ namespace Box
   box : Rect -> Context ()
   box r = do
     -- draw the lines at full size
-    hline r.nw r.size.width
-    hline r.sw r.size.width
-    vline r.nw r.size.height
-    vline r.ne r.size.height
+    hline r.nw r.hspan
+    hline r.sw r.hspan
+    vline r.nw r.vspan
+    vline r.ne r.vspan
     -- paint over with the corners
     putAt r.nw NW
     putAt r.ne NE


### PR DESCRIPTION
Basically, math on a character grid is annoying and full of edge cases.

The main thing is that the `split*` and `pack*` functions work as expected.

Also fixing up run.sh, which somehow got clobbered (again). And making sure ./run.sh properly exports LINES and COLUMNS.