### PR TITLE
Prefill Spinner

### DIFF
--- a/examples/gallery/src/Main.idr
+++ b/examples/gallery/src/Main.idr
@@ -1,6 +1,7 @@
 module Main
 
 
+import Data.List
 import TUI
 import TUI.MainLoop
 import TUI.MainLoop.Default
@@ -26,7 +27,7 @@ testCounter = component @{show} 0 onKey unavailable
 
 ||| A simple menu
 testMenu : Component String
-testMenu = spinner ["foo", "bar", "baz"]
+testMenu = Spinner.fromChoice ["foo", "bar", "baz"] "bar"
 
 ||| A component that represents a user-chosen value
 data TestModal = Default String | Selected String String

--- a/src/TUI/Component/Menu.idr
+++ b/src/TUI/Component/Menu.idr
@@ -33,6 +33,7 @@ module TUI.Component.Menu
 
 import Data.Fin
 import Data.List
+import Data.List.Elem
 import Data.Nat
 import TUI.Component
 import TUI.Layout
@@ -44,15 +45,24 @@ import TUI.View
 %default total
 
 
-||| XXX: this could easily support multiple selection!
-
-
 ||| Represents an exclusive choice
 export
 record Exclusive itemT where
   constructor MkChoice
   choices       : List itemT
   choice        : Fin (length choices)
+
+-- use (.dotted) version of these projection functions instead.
+%hide Exclusive.choices
+%hide Exclusive.choice
+
+||| Construct a new Exclusive value with the given choice.
+export
+new
+  :  (choices : List itemT)
+  -> (choice : Fin (length choices))
+  -> Exclusive itemT
+new choices choice = MkChoice choices choice
 
 ||| Get the selected value.
 export
@@ -88,8 +98,23 @@ arrowForIndex (FS n) = if FS n == last
   then arrow Up
   else arrow UpDown
 
+||| A visually-compact Component representing an exclusive choice.
+|||
+||| It is rendered as a single value. The user can cycle through this
+||| value via the arrow keys.
+|||
+||| One of the guarantees provided by this component is that the
+||| yielded value *must* be an element of the given type.
+|||
+||| XXX: Ideally this guarantee would be expressed in the type system.
 namespace Spinner
 
+  ||| The View implementation renders the component value, plus an
+  ||| arrow indicator, which signals whether the user is at the
+  ||| beginning, middle, or end of the list of choices. Also, that
+  ||| it's a spinner to begin with.
+  |||
+  ||| If the spinner is given more vertical space
   export
   View itemT => View (Exclusive itemT) where
     size self =
@@ -101,30 +126,62 @@ namespace Spinner
       withState state $ showTextAt window.nw (arrowForIndex self.choice)
       paint state (window.shiftRight 2) self.selected
 
+  ||| Interaction with the user is via the up, down, enter, and escape
+  ||| keys.
+  |||
+  ||| Up / Down cycle through the combinations
   export
-  handle : Component.Handler (Exclusive itemT) itemT Key
-  handle Up     self = update $ prev self
-  handle Down   self = update $ next self
-  handle Left   self = exit
-  handle Escape self = exit
-  handle Enter  self = yield self.selected
-  handle _      _    = ignore
+  onKey : Component.Handler (Exclusive itemT) itemT Key
+  onKey Up     self = update $ prev self
+  onKey Down   self = update $ next self
+  onKey Left   self = exit
+  onKey Escape self = exit
+  onKey Enter  self = yield self.selected
+  onKey _      _    = ignore
 
-  export
-  new
-    :  (choices    : List itemT)
-    -> {auto 0 prf : IsJust (natToFin 0 (length choices))}
-    -> Exclusive itemT
-  new choices = MkChoice choices $ fromJust $ natToFin 0 (length choices)
-
+  ||| Construct a spinner with the given numeric choice set as the
+  ||| default.
   export
   spinner
     :  View itemT
-    => (choices    : List itemT)
-    -> {auto 0 prf : IsJust (natToFin 0 (length choices))}
+    => (choices : List itemT)
+    -> (choice  : Fin (length choices))
     -> Component itemT
-  spinner {itemT} choices = component {
-    state   = (new choices),
-    handler = handle,
+  spinner {itemT} choices choice = component {
+    state   = (new choices choice),
+    handler = onKey,
     get     =  Just . (.selected)
   }
+
+  ||| Construct a spinner using an explicit value.
+  |||
+  ||| This value must be provably an element of the list. This variant
+  ||| is most useful when the list and element are constant.
+  |||
+  ||| Note: you may need to import Data.List in order to call this
+  ||| function.
+  export
+  fromChoice
+    :  View itemT
+    => Eq itemT
+    => (choices  : List itemT)
+    -> (choice   : itemT)
+    -> {auto 0 has : IsJust (findIndex (choice ==) choices)}
+    -> Component itemT
+  fromChoice choices choice {has} = spinner choices index
+    where
+      index : Fin (length choices)
+      index = fromJust (findIndex (choice ==) choices)
+
+  ||| Like `fromChoice`, but doesn't require a proof of membership
+  ||| (returning a Maybe) instead.
+  export
+  maybeFromChoice
+    :  View itemT
+    => Eq itemT
+    => (choices : List itemT)
+    -> (choice  : itemT)
+    -> Maybe (Component itemT)
+  maybeFromChoice choices choice = spinner {
+    choices = choices
+  } <$> findIndex (choice ==) choices


### PR DESCRIPTION
Previously a spinner's value defaulted to index 0. This change requires an argument to be given by the caller.