### PR TITLE
[ cleanup ] ditch dependency on contrib

### DIFF
--- a/src/TUI/Painting.idr
+++ b/src/TUI/Painting.idr
@@ -30,7 +30,7 @@
 ||| Immediate-mode TUI graphics.
 |||
 ||| These routines are slightly higher-level than that provided by
-||| `Control.ANSI`. In particular, we use types from `TUI.Geometry`.
+||| `Text.ANSI`. In particular, we use types from `TUI.Geometry`.
 |||
 ||| These routines operate on an opaque `Context` which theoretically
 ||| tracks the draw state, allowing for scope-based mangement of draw
@@ -57,7 +57,7 @@
 module TUI.Painting
 
 
-import public Control.ANSI
+import public Text.ANSI
 import Data.String
 import System
 import System.File

--- a/src/TUI/Util.idr
+++ b/src/TUI/Util.idr
@@ -47,7 +47,6 @@ import Data.String
 import Data.SortedMap
 import Data.Vect
 import Data.Vect.Quantifiers
-import Language.JSON
 
 
 %default total

--- a/tui.ipkg
+++ b/tui.ipkg
@@ -5,7 +5,7 @@ maintainers = "emdash"
 license = "BSD-3"
 brief = "Easy terminal UI for Idris2"
 
-depends = contrib
+depends = ansi
         , json
         , elab-util
         , quantifiers-extra


### PR DESCRIPTION
Eventually, contrib should be disbanded and split into parts that go into base and stuff that should go to community projects. `Control.ANSI` has been moved to its own library on [idris-community](https://github.com/idris-community/idris2-ansi). With this PR, the dependency on contrib is removed.