### PR TITLE
[ refactor ] use unbuffered IO for rendering and generalize some IO actions

### DIFF
--- a/.github/workflows/ci-lib.yml
+++ b/.github/workflows/ci-lib.yml
@@ -29,12 +29,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build lib
-        run: pack build tui
+        run: pack --no-prompt build tui
       - name: Build gallery
-        run: pack build gallery
+        run: pack --no-prompt build gallery
       - name: Build scrollclip
-        run: pack build scrollclip
+        run: pack --no-prompt build scrollclip
       - name: Build todo
-        run: pack build todo
+        run: pack --no-prompt build todo
       - name: Build user_event
-        run: pack build user_event
+        run: pack --no-prompt build user_event

--- a/src/TUI/Geometry.idr
+++ b/src/TUI/Geometry.idr
@@ -371,13 +371,13 @@ r80x24 = MkRect origin (MkArea 80 24)
 |||
 ||| XXX: handle SIGWINCH
 export
-screen : IO Rect
+screen : HasIO io => io Rect
 screen = do
   width  <- parseEnv "COLUMNS" 80 parsePositive
   height <- parseEnv  "LINES"  24 parsePositive
   pure $ MkRect origin $ MkArea (width `minus` 1) (height `minus` 1)
 where
-  parseEnv : String -> a -> (String -> Maybe a) -> IO a
+  parseEnv : String -> a -> (String -> Maybe a) -> io a
   parseEnv key def parse = case !(getEnv key) of
     Just value => pure $ fromMaybe def $ parse value
     Nothing    => pure def

--- a/src/TUI/Image.idr
+++ b/src/TUI/Image.idr
@@ -38,7 +38,6 @@ module TUI.Image
 
 
 import System
-import System.File
 import TUI.Geometry
 import TUI.Painting
 import TUI.View

--- a/src/TUI/MainLoop/Base.idr
+++ b/src/TUI/MainLoop/Base.idr
@@ -36,10 +36,9 @@ module TUI.MainLoop.Base
 
 import Data.IORef
 import System
+import System.File
 import System.Concurrency
-import System.File.Process
-import System.File.ReadWrite
-import System.File.Virtual
+import System.Posix.File
 import TUI.DFA
 import TUI.Event
 import TUI.Key
@@ -94,7 +93,6 @@ MainLoop Base (HSum [Key]) where
         moveTo origin
         render state
       endSyncUpdate
-      fflush stdout
       case next !getChar decoder of
         Discard => loop decoder state
         Advance decoder Nothing => loop decoder state
@@ -103,7 +101,7 @@ MainLoop Base (HSum [Key]) where
           Right value => pure $ value
         Accept state => assert_total $ idris_crash "ANSI decoder in final state!"
         Reject str => do
-          ignore $ fPutStrLn stderr "ANSI Decode Error: \{str}"
+          stderrLn "ANSI Decode Error: \{str}"
           loop (reset decoder) state
 
 ||| Special case for a singleton set of events

--- a/tui.ipkg
+++ b/tui.ipkg
@@ -9,6 +9,7 @@ depends = ansi
         , json
         , elab-util
         , quantifiers-extra
+        , posix
 
 modules = TUI
         , TUI


### PR DESCRIPTION
These are some very small changes. I didn't touch `IO` with components yet, even though these might be an issue when working with other even loops as they might run in their own monad. But I haven't figured out how components work yet, so that will be the next step.