### PR TITLE
Dusting off the cobwebs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # `idris-tui`
 
-Aa framework for TUI applications in Idris.
+The key feature that is needed is sync updates (see this for more info):
+https://github.com/contour-terminal/vt-extensions/blob/master/synchronized-output.md
 
 List of supported terminals:
 - iTerm2
@@ -10,7 +11,9 @@ List of supported terminals:
 
 List of unsupported terminals:
 - intelliJ (not tested)
-- tmux (no sync update, to investigate)
+- tmux
+  - feature is listed (`-T sync`), but doesn't seem to work in practice:
+  - https://github.com/tmux/tmux/issues/4299
 - VTE terminals (not tested)
 - anything not mentioned above.
 

--- a/pack.toml
+++ b/pack.toml
@@ -23,27 +23,6 @@ type   = "local"
 path   = "examples/user_event/"
 ipkg   = "user_event.ipkg"
 
-# Using upstream async:main for now.
-# Remove these when official async stabilizes.
-
-[custom.all.async]
-type = "github"
-url  = "https://github.com/stefan-hoeck/idris2-async"
-commit = "latest:main"
-ipkg = "async.ipkg"
-
-[custom.all.async-posix]
-type = "github"
-url  = "https://github.com/stefan-hoeck/idris2-async"
-commit = "latest:main"
-ipkg = "async-posix/async-posix.ipkg"
-
-[custom.all.async-epoll]
-type = "github"
-url  = "https://github.com/stefan-hoeck/idris2-async"
-commit = "latest:main"
-ipkg = "async-epoll/async-epoll.ipkg"
-
 [custom.all.tui-async]
 type = "local"
 path = "tui-async"

--- a/src/TUI/MainLoop/InputShim.idr
+++ b/src/TUI/MainLoop/InputShim.idr
@@ -71,7 +71,7 @@ record EventSource eventT where
   0 RawEventT : Type
   tag         : String
   {auto impl  : FromJSON RawEventT}
-  decoder     : IORef $ Automaton RawEventT eventT
+  decoder     : IORef.IORef $ Automaton RawEventT eventT
 
 ||| A MainLoop which receive events as a stream of JSON records on STDIN.
 |||


### PR DESCRIPTION
Get this building again after a long break.

- dependencies no longer need custom entries in pack.toml.
- one identifier had become ambiguous and needed qualification.
- update readme with some new information