### PR TITLE
Offscreen Scroll

### DIFF
--- a/examples/scrollclip/pack.toml
+++ b/examples/scrollclip/pack.toml
@@ -1,15 +1,9 @@
 [custom.all.scrollclip]
 type = "local"
 path = "."
-ipkg = "todo.ipkg"
-test = "test/test.ipkg"
-
-[custom.all.scrollclip-test]
-type = "local"
-path = "test"
-ipkg = "test.ipkg"
+ipkg = "scrollclip.ipkg"
 
 [custom.all.tui]
 type = "local"
-path = "../../"
+path = "../.."
 ipkg = "tui.ipkg"

--- a/examples/scrollclip/scrollclip.ipkg
+++ b/examples/scrollclip/scrollclip.ipkg
@@ -13,8 +13,7 @@ authors = "emdash"
 -- langversion
 
 -- packages to add to search path
-depends = contrib
-	, tui
+depends = tui
 
 -- modules to install
 -- modules =

--- a/examples/scrollclip/src/Main.idr
+++ b/examples/scrollclip/src/Main.idr
@@ -36,11 +36,7 @@ View a => View (ViewPort a) where
     showTextAt (MkPos 0 81) $ show window
   where
     offset : Rect -> (Integer, Integer) -> Rect
-    offset self (x, y) = case (x < 0, y < 0) of
-      (True, True)   => (self.shiftLeft  $ cast $ -x).shiftUp   $ cast $ -y
-      (True, False)  => (self.shiftLeft  $ cast $ -x).shiftDown $ cast    y
-      (False, True)  => (self.shiftRight $ cast    x).shiftUp   $ cast $ -y
-      (False, False) => (self.shiftRight $ cast    x).shiftDown $ cast    y
+    offset self (x, y) = (self.shiftX x).shiftY y
 
 [mine] View (Integer, Integer) where
   size = const $ MkArea 0 0

--- a/src/TUI/Component/Form.idr
+++ b/src/TUI/Component/Form.idr
@@ -172,7 +172,7 @@ implementation
 where
   size self = vunion (size @{vertical} self.fields) (size self.focus)
   paint state window self = do
-    vline (window.nw.shiftRight (self.split + 1)) window.height
+    vline (window.nw.shiftRight (cast $ self.split + 1)) window.height
     ignore $ packTop @{vertical} fieldsState window self.fields
     ignore $ packBottom state window self.focus
   where

--- a/src/TUI/Geometry.idr
+++ b/src/TUI/Geometry.idr
@@ -47,8 +47,8 @@ import TUI.Prim
 public export
 record Pos where
   constructor MkPos
-  x : Nat
-  y : Nat
+  x : Integer
+  y : Integer
 %runElab derive "Pos" [Eq, Ord, Show]
 
 ||| The dimensions of a screen view
@@ -70,6 +70,7 @@ record Rect where
   size : Area
 %runElab derive "Rect" [Eq, Ord, Show]
 
+
 namespace Pos
 
   ||| Top-left screen corner
@@ -79,43 +80,43 @@ namespace Pos
 
   public export
   (.shiftRight) : Pos -> Nat -> Pos
-  (.shiftRight) self offset = { x $= (+ offset) } self
+  (.shiftRight) self offset = { x $= (+ (natToInteger offset)) } self
 
   public export
   (.shiftLeft) : Pos -> Nat -> Pos
-  (.shiftLeft) self offset = { x $= (`minus` offset) } self
+  (.shiftLeft) self offset = { x $= ((flip (-)) (natToInteger offset)) } self
 
   public export
   (.shiftDown) : Pos -> Nat -> Pos
-  (.shiftDown) self offset = { y $= (+ offset) } self
+  (.shiftDown) self offset = { y $= (+ (natToInteger offset)) } self
 
   public export
   (.shiftUp) : Pos -> Nat -> Pos
-  (.shiftUp) self offset = { y $= (`minus` offset) } self
+  (.shiftUp) self offset = { y $= ((flip (-)) (natToInteger offset)) } self
 
 namespace OverloadsPosAreaPos
   ||| Adding a point to an area returns a new point.
   public export
   (+) : Pos -> Area -> Pos
-  (+) (MkPos x y) (MkArea w h) = MkPos (x + w) (y + h)
+  (+) (MkPos x y) (MkArea w h) = MkPos (x + natToInteger w) (y + natToInteger h)
 
   public export
   (-) : Pos -> Area -> Pos
-  a - v = MkPos (a.x `minus` v.width) (a.y `minus` v.height)
+  a - v = MkPos (a.x - natToInteger v.width) (a.y - natToInteger v.height)
 
 namespace OverloadsPosPosArea
   public export
   (-) : Pos -> Pos -> Area
   (-) a b = MkArea (a.x `diff` b.x) (a.y `diff` b.y)
 
-namespace OverloadsNatPosPos
+namespace OverloadsIntegerPosPos
   public export
-  (*) : Nat -> Pos -> Pos
+  (*) : Integer -> Pos -> Pos
   scalar * pos = MkPos (scalar * pos.x) (scalar * pos.y)
 
-namespace OverloadsPosNatPos
+namespace OverloadsPosIntegerPos
   public export
-  (*) : Pos -> Nat -> Pos
+  (*) : Pos -> Integer -> Pos
   pos * scalar = MkPos (scalar * pos.x) (scalar * pos.y)
 
 namespace OverloadsNatAreaArea
@@ -197,23 +198,23 @@ namespace Rect
 
   ||| The column of the left side of the rect
   export
-  (.w) : Rect -> Nat
+  (.w) : Rect -> Integer
   (.w) b = b.pos.x
 
   ||| The column of the east side of the rect
   export
-  (.e) : Rect -> Nat
-  (.e) b = b.pos.x + b.hspan
+  (.e) : Rect -> Integer
+  (.e) b = b.pos.x + natToInteger b.hspan
 
   ||| The row of the north side of the rect
   export
-  (.n) : Rect -> Nat
+  (.n) : Rect -> Integer
   (.n) b = b.pos.y
 
   ||| The row of the south side of the rect.
   export
-  (.s) : Rect -> Nat
-  (.s) b = b.pos.y + b.vspan
+  (.s) : Rect -> Integer
+  (.s) b = b.pos.y + natToInteger b.vspan
 
   ||| Northwest corner of the given rect
   export
@@ -410,7 +411,6 @@ shrink r = inset r $ MkArea 1 1
 export
 grow : Rect -> Rect
 grow r = outset r $ MkArea 1 1
-
 
 namespace Test
   0 TestPos : Pos

--- a/src/TUI/Geometry.idr
+++ b/src/TUI/Geometry.idr
@@ -79,20 +79,20 @@ namespace Pos
   origin = MkPos 1 1
 
   public export
-  (.shiftRight) : Pos -> Nat -> Pos
-  (.shiftRight) self offset = { x $= (+ (natToInteger offset)) } self
+  (.shiftRight) : Pos -> Integer -> Pos
+  (.shiftRight) self offset = { x $= (+ offset) } self
 
   public export
-  (.shiftLeft) : Pos -> Nat -> Pos
-  (.shiftLeft) self offset = { x $= ((flip (-)) (natToInteger offset)) } self
+  (.shiftLeft) : Pos -> Integer -> Pos
+  (.shiftLeft) self offset = { x $= ((flip (-)) offset) } self
 
   public export
-  (.shiftDown) : Pos -> Nat -> Pos
-  (.shiftDown) self offset = { y $= (+ (natToInteger offset)) } self
+  (.shiftDown) : Pos -> Integer -> Pos
+  (.shiftDown) self offset = { y $= (+ offset) } self
 
   public export
-  (.shiftUp) : Pos -> Nat -> Pos
-  (.shiftUp) self offset = { y $= ((flip (-)) (natToInteger offset)) } self
+  (.shiftUp) : Pos -> Integer -> Pos
+  (.shiftUp) self offset = { y $= ((flip (-)) offset) } self
 
 namespace OverloadsPosAreaPos
   ||| Adding a point to an area returns a new point.
@@ -255,7 +255,7 @@ namespace Rect
   (.splitRight) : Rect -> Nat -> (Rect, Rect)
   (.splitRight) b w =
     let
-      right = fromPoints (b.ne.shiftLeft (w `minus` 1)) (b.se + unit)
+      right = fromPoints (b.ne.shiftLeft (cast (w `minus` 1))) (b.se + unit)
       left  = fromPoints b.nw $ right.sw.shiftDown 1
     in (left, right)
 
@@ -273,7 +273,7 @@ namespace Rect
   (.splitBottom) : Rect -> Nat -> (Rect, Rect)
   (.splitBottom) b h =
     let
-      bot = fromPoints (b.sw.shiftUp (h `minus` 1)) (b.se + unit)
+      bot = fromPoints (b.sw.shiftUp (cast (h `minus` 1))) (b.se + unit)
       top = fromPoints b.nw $ bot.ne.shiftRight 1
     in (top, bot)
 
@@ -305,6 +305,16 @@ namespace Rect
   relativeTo (MkRect nw _) (MkRect offset size) =
     let pos = MkPos (nw.x + offset.x) (nw.y + offset.y)
     in MkRect pos size
+
+  ||| Like shiftRight, but takes an Integer. Negative offset shifts left.
+  public export
+  (.shiftX) : Rect -> Integer -> Rect
+  (.shiftX) self offset = { pos $= ((flip (.shiftRight)) offset) } self
+
+  ||| Like shiftDown, but takes an Integer. Negative offset shifts up.
+  public export
+  (.shiftY) : Rect -> Integer -> Rect
+  (.shiftY) self offset = { pos $= ((flip (.shiftDown)) offset) } self
 
   public export
   (.shiftRight) : Rect -> Nat -> Rect

--- a/src/TUI/Painting.idr
+++ b/src/TUI/Painting.idr
@@ -162,7 +162,7 @@ clearMasked window mask =
       j <- [1 .. window.height]
       case mask.contains $ MkPos (natToInteger i) (natToInteger j) of
         True  => []
-        False => [cursorMove i j, " "]
+        False => [cursorMove j i, " "]
 
 ||| Paint the context to stdout.
 export

--- a/src/TUI/Painting.idr
+++ b/src/TUI/Painting.idr
@@ -27,7 +27,7 @@
   -- OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
   -- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-  ||| Immediate-mode TUI graphics.
+||| Immediate-mode TUI graphics.
 |||
 ||| These routines are slightly higher-level than that provided by
 ||| `Text.ANSI`. In particular, we use types from `TUI.Geometry`.

--- a/src/TUI/Painting.idr
+++ b/src/TUI/Painting.idr
@@ -64,20 +64,6 @@ import public TUI.Geometry
 
 %default total
 
-||| Distinguish Display Coordinates from Logical Coordinates.
-|||
-||| Geometry uses signed positions to allow calculating with negative
-||| positions. This is needed to allow scolling content past the edge of the
-||| screen.
-|||
-||| However, Actual terminals do not work with negative indices. This enforces
-||| that cordinates are clamped to the actual display geometry prior to output.
--- public export
--- record Pos where
---   constructor MkPos
---   x : Nat
---   y : Nat
-
 
 ||| Abstract over writing to the console.
 |||

--- a/src/TUI/Util.idr
+++ b/src/TUI/Util.idr
@@ -193,6 +193,11 @@ namespace Data.Nat
     True  => b `minus` a
     False => a `minus` b
 
+namespace Data.Integer
+  ||| Same as above, but the operands are integers.
+  public export
+  diff : Integer -> Integer -> Nat
+  diff a b = integerToNat $ abs $ a - b
 
 namespace Data.Vect.Quantifiers
   ||| Map a function over a heterogenous vector.


### PR DESCRIPTION
Changed `Geometry.Pos` to use `Integer` coordinates, such that we can now calculate negative positions.

The `cursorMove` function in the ANSI library takes `Nat`, so this ensures that all real negative coordinate values get clamped to 0 before display.