### PR TITLE
Remove public export of JSON library

### DIFF
--- a/src/TUI/Component/TextInput.idr
+++ b/src/TUI/Component/TextInput.idr
@@ -126,4 +126,3 @@ export
 {0 events : List Type} -> Has Key events => Editable events String where
   fromValue = textInput {events}
   blank     = textInput {events} ""
-

--- a/src/TUI/Event.idr
+++ b/src/TUI/Event.idr
@@ -42,7 +42,7 @@ module TUI.Event
 
 
 import Data.IORef
-import public JSON
+import JSON
 import JSON.Derive
 import TUI.DFA
 import Data.List

--- a/src/TUI/MainLoop/InputShim.idr
+++ b/src/TUI/MainLoop/InputShim.idr
@@ -50,6 +50,7 @@ import TUI.Event
 import TUI.Key
 import TUI.MainLoop
 import TUI.Painting
+import JSON
 
 
 %default total


### PR DESCRIPTION
I am beginning to migrate to `json-simple`, now that I understand how pack works better.